### PR TITLE
FIX When both users click Complete Swap, this changes the contract status to Completed

### DIFF
--- a/client/components/Account.js
+++ b/client/components/Account.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import {connect} from 'react-redux'
 import { withRouter, Link } from 'react-router-dom'
+import {logout, stopGethInst} from '../store'
 
 
 const Account = (props) => {
@@ -27,10 +28,16 @@ const mapState = (state) => {
 
 const mapDispatch = (dispatch, ownProps) => {
     return {
-
+        handleClick (evt, user, stopGeth) {
+            dispatch(logout())
+            stopGeth(user)
+          },
+          stopGeth (user) {
+            dispatch(stopGethInst(user))
+          }
     }
 }
 
 // delete me later
 
-export default connect(mapState, mapDispatch)(Account)
+export default withRouter(connect(mapState, mapDispatch)(Account))

--- a/client/components/Main.js
+++ b/client/components/Main.js
@@ -53,6 +53,7 @@ const Main = (props) => {
               <Link to="/basket" className="nav-item"><i className="fas fa-shopping-basket" />({basket.length})</Link>
               <Link to="/inbox" className="nav-item"><i className="fas fa-envelope" />({Object.keys(inbox).length})</Link>
               <Link to="/account" className="nav-item"><i className="fas fa-cog" /></Link>
+              <a href="/" onClick={(event) => handleClick(event, user, stopGeth)}>Logout</a>
             </nav>
         }
       <hr className="title-hr"/>

--- a/client/components/RequestTicket.js
+++ b/client/components/RequestTicket.js
@@ -181,7 +181,7 @@ const mapDispatch = (dispatch, ownProps) => {
             dispatch(updateContractStatus(+contract.id, { status: 'Pending' }))
         },
         completeSwapHandler: (contract, currentUser) => {
-            console.log('CONTRACT!!!!', contract)
+            console.log('CONTRACTANDCURRENTUSER', contract, currentUser)
             dispatch(completeContractStatus(contract, currentUser))
         }
 

--- a/client/store/contract.js
+++ b/client/store/contract.js
@@ -83,7 +83,8 @@ export const completeContractStatus = (contract, currentUser) => dispatch => {
   // update the user's contractAssociation for this contract to itemReceived: true
 axios.put(`/api/contractassociations/complete/${contractId}`, {userId})
   .then(res => {
-    if (res === 'Completed') {
+    console.log('WHATISTHERES', res)
+    if (res.data === 'Completed') {
       dispatch(updateContractStatus(contractId, {status: 'Completed'}))
     }
   })

--- a/client/store/contract.js
+++ b/client/store/contract.js
@@ -77,13 +77,21 @@ export const updateContractStatus = (contractId, status) => dispatch => {
 export const completeContractStatus = (contract, currentUser) => dispatch => {
   const contractAddress = contract.address
   const contractId = contract.id
+  const userId = currentUser.id
 
-  // update the contract status in solidity via web3 to completed
-  axios.post('/web3/complete', {contractAddress, currentUser})
+
+  // update the user's contractAssociation for this contract to itemReceived: true
+axios.put(`/api/contractassociations/complete/${contractId}`, {userId})
   .then(res => {
-    console.log('THIS IS THE RESULT FROM WEB3 AFTER COMPLETE', res.data)
-    dispatch(updateContractStatus(contractId, {status: 'Completed'}))
+    if (res === 'Completed') {
+      dispatch(updateContractStatus(contractId, {status: 'Completed'}))
+    }
   })
+
+  // if both the associations are itemReceived: true, then updateContractStatus to completed
+
+  // dispatch(updateContractStatus(contractId, {status: 'Completed'}))
+
   .catch(err => console.log(err))
 }
 

--- a/client/store/contract.js
+++ b/client/store/contract.js
@@ -37,6 +37,7 @@ export const createContractApi = (items, currentUser, soliciteeId) => dispatch =
   let currentUserId = currentUser.id
   let allItems = items.map(item => item.name).join(', ');
   let itemIds = []
+  let contractAddress = 12345
   items.forEach(itemObj => {
     itemIds.push(itemObj.id)
   })

--- a/client/store/offer.js
+++ b/client/store/offer.js
@@ -30,17 +30,12 @@ export const updateContract = (items, contract, solicitor, solicitorId, currentU
     let itemIds = []
     items.forEach(itemObj => {itemIds.push(itemObj.id)})
     itemIds = itemIds.join(', ')
-    axios.post('/web3/contract', {allItems, currentUser, contractAddress})
-    .then(res => {
-      console.log('----Reached other side of web3/contract POST----')
-      console.log("RES.DATA (contractAddress): ", res.data)
       dispatch(updateContractAssoc(contract.id, currentUser.id, itemIds))
       dispatch(updateContractStatus(contract.id, {status: 'SecondReview'}))
-      console.log("** MADE IT THROUGH UpdateContract **")
- //   dispatch(fetchContracts())
-    })
     .catch(err => console.log(err))
   }
+
+
 /**
  * REDUCER
  */

--- a/server/api/contractassociations.js
+++ b/server/api/contractassociations.js
@@ -85,16 +85,17 @@ router.put('/complete/:contractId', (req, res, next) => {
   }})
   .then(contractAssoc => {
     console.log('ASSOCHERE', contractAssoc)
-    return contractAssoc.update({itemReceived: true})
+    contractAssoc.update({itemReceived: true})
   })
   .then(() => {
-    ContractAssociations.findOne({where: {
+    return ContractAssociations.findOne({where: {
       userId: {
         $ne: req.body.userId
       },
       contractId: req.params.contractId
     }})
     .then(otherUserCA => {
+      console.log('OTHERUSERCA', otherUserCA)
       if (otherUserCA.itemReceived === true) {
         res.json('Completed')
       } else {

--- a/server/api/contractassociations.js
+++ b/server/api/contractassociations.js
@@ -59,6 +59,7 @@ router.get('/ledger/:contractId', (req, res, next) => {
     .catch(next)
 })
 
+
 router.put('/:contractId', (req, res, next) => {
   console.log('REQ>BODYSOLICITEEID', req.body.soliciteeId)
   return ContractAssociations.findOne({where: {
@@ -74,6 +75,36 @@ router.put('/:contractId', (req, res, next) => {
   })
   .catch(next)
 })
+
+router.put('/complete/:contractId', (req, res, next) => {
+  console.log('REQ.BODY COMPLETE CONTRACTASSOCATIONS: ', req.body)
+  console.log('REQ.PARAMS COMPLETE CONTRACTASSOCATIONS: ', req.params)
+  return ContractAssociations.findOne({where: {
+    userId: req.body.userId,
+    contractId: req.params.contractId
+  }})
+  .then(contractAssoc => {
+    console.log('ASSOCHERE', contractAssoc)
+    return contractAssoc.update({itemReceived: true})
+  })
+  .then(() => {
+    ContractAssociations.findOne({where: {
+      userId: {
+        $ne: req.body.userId
+      },
+      contractId: req.params.contractId
+    }})
+    .then(otherUserCA => {
+      if (otherUserCA.itemReceived === true) {
+        res.json('Completed')
+      } else {
+        res.json('Pending')
+      }
+    })
+  })
+})
+
+
 
 
 module.exports = router;

--- a/server/db/models/ContractAssociations.js
+++ b/server/db/models/ContractAssociations.js
@@ -7,6 +7,10 @@ const ContractAssociations = db.define('contractAssociation', {
   },
   comment: {
     type: Sequelize.STRING
+  },
+  itemReceived: {
+    type: Sequelize.BOOLEAN,
+    defaultValue: false
   }
 })
 


### PR DESCRIPTION
- Added **itemReceived** field to ContractAssociations model to track when each user clicks 'Complete Swap'
- Added **/api/contractassociations/complete/:contractId** route to change each user's itemReceived field to 'true' if they clicked the button. This route also checks the other user's itemReceived field, and if both are true, this returns 'Completed' to store/contract, which then dispatches updateContractStatus