### PR TITLE
reworked contractAddress assignment for deployed version

### DIFF
--- a/server/api/contracts.js
+++ b/server/api/contracts.js
@@ -20,24 +20,27 @@ router.get('/completed', (req, res, next) => {
 })
 
 router.post('/', (req, res, next) => {
-  contractAddress++
+  // contractAddress++
 
     Contract.create({contractAddress})
     .then(newContract => {
+      return newContract.update({contractAddress: newContract.id})
+    })
+    .then(contract => {
         ContractAssociations.bulkCreate([{
-            contractId: newContract.id,
+            contractId: contract.id,
             userId: req.body.currentUserId,
             itemIds: req.body.itemIds
         },
         {
-            contractId: newContract.id,
+            contractId: contract.id,
             userId: req.body.soliciteeId
         }])
-        return newContract
+        return contract
     })
-    .then(newContract => {
-        console.log("New Contract: ", newContract)
-        res.json(newContract)
+    .then(contract => {
+        console.log("New Contract: ", contract)
+        res.json(contract)
     })
     .catch(err => console.log(err))
 })
@@ -55,4 +58,3 @@ router.put('/:contractId', (req, res, next) => {
 })
 
 module.exports = router;
-


### PR DESCRIPTION
New contracts are created with a placeholder address, and that address is reassigned to the same number as its primary key immediately after creation. The database is updated appropriately and there are are no errors that show, but I'm not sure that the inbox/request ticket is rendering the new contract information correctly.